### PR TITLE
navbar update

### DIFF
--- a/src/segments/Navbar/Navbar.jsx
+++ b/src/segments/Navbar/Navbar.jsx
@@ -43,7 +43,7 @@ const Navbar = () => {
       <nav
         id="navbar"
         className={drop ? "blur drop" : ""}
-        style={{ background: convertHexToRgba("--bg-base", 0.8) }}
+        style={{ background: drop ? convertHexToRgba("--bg-base", 0.8) : "transparent" }}
       >
         <ShreeLogo />
         <div className="route-wrapper">


### PR DESCRIPTION
If drop is truthy, the background is set to an RGBA color derived from --bg-base with an opacity of 0.8.
If drop is falsy, the background is set to transparent.